### PR TITLE
页面数据导出excel

### DIFF
--- a/fetch_to_excel.py
+++ b/fetch_to_excel.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+Fetch paginated data via HTTP GET and export to Excel.
+
+Example:
+  python fetch_to_excel.py \
+    --url "https://api.example.com/items" \
+    --page 1 --limit 10 --keyword "foo" --enabled true \
+    --all-pages --output "data.xlsx"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+FIELD_ORDER = [
+    "id",
+    "position",
+    "document_id",
+    "content",
+    "sign_content",
+    "answer",
+    "word_count",
+    "tokens",
+    "keywords",
+    "index_node_id",
+    "index_node_hash",
+    "hit_count",
+    "enabled",
+    "disabled_at",
+    "disabled_by",
+    "status",
+    "created_by",
+    "created_at",
+    "updated_at",
+    "updated_by",
+    "indexing_at",
+    "completed_at",
+    "error",
+    "stopped_at",
+]
+
+
+def parse_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+    value = value.strip().lower()
+    if value in {"true", "1", "yes", "y"}:
+        return True
+    if value in {"false", "0", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError(
+        "enabled must be one of: true/false/1/0/yes/no"
+    )
+
+
+def build_url(base_url: str, params: Dict[str, Any]) -> str:
+    url_parts = urlsplit(base_url)
+    query_items = dict(parse_qsl(url_parts.query, keep_blank_values=True))
+    for key, value in params.items():
+        if value is None:
+            continue
+        query_items[key] = str(value)
+    new_query = urlencode(query_items, doseq=True)
+    return urlunsplit(
+        (url_parts.scheme, url_parts.netloc, url_parts.path, new_query, url_parts.fragment)
+    )
+
+
+def http_get_json(url: str, timeout: int) -> Dict[str, Any]:
+    request = Request(url, headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = response.read().decode("utf-8")
+    except HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code}: {exc.reason}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Network error: {exc.reason}") from exc
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Response is not valid JSON") from exc
+
+
+def normalize_value(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return value
+
+
+def build_columns(records: Iterable[Dict[str, Any]]) -> List[str]:
+    extra_keys = set()
+    for record in records:
+        extra_keys.update(record.keys())
+    ordered = [key for key in FIELD_ORDER if key in extra_keys]
+    remaining = sorted(extra_keys - set(ordered))
+    return ordered + remaining
+
+
+def write_excel(records: List[Dict[str, Any]], output_path: str) -> None:
+    try:
+        from openpyxl import Workbook
+        from openpyxl.utils import get_column_letter
+    except ImportError as exc:
+        raise RuntimeError(
+            "Missing dependency: openpyxl. Install with: pip install openpyxl"
+        ) from exc
+
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "data"
+
+    if not records:
+        sheet.append(["no data"])
+        workbook.save(output_path)
+        return
+
+    columns = build_columns(records)
+    sheet.append(columns)
+
+    for record in records:
+        row = [normalize_value(record.get(column)) for column in columns]
+        sheet.append(row)
+
+    # Light column sizing for readability (cap width at 50).
+    for idx, column_name in enumerate(columns, start=1):
+        max_len = len(str(column_name))
+        for row_idx in range(2, min(sheet.max_row, 2000) + 1):
+            value = sheet.cell(row=row_idx, column=idx).value
+            if value is None:
+                continue
+            max_len = max(max_len, len(str(value)))
+        sheet.column_dimensions[get_column_letter(idx)].width = min(50, max(10, max_len + 2))
+
+    workbook.save(output_path)
+
+
+def fetch_pages(
+    base_url: str,
+    page: int,
+    limit: int,
+    keyword: Optional[str],
+    enabled: Optional[bool],
+    all_pages: bool,
+    timeout: int,
+    sleep_seconds: float,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    metadata: Dict[str, Any] = {}
+
+    current_page = page
+    while True:
+        params = {
+            "page": current_page,
+            "limit": limit,
+            "keyword": keyword,
+            "enabled": str(enabled).lower() if enabled is not None else None,
+        }
+        url = build_url(base_url, params)
+        response = http_get_json(url, timeout=timeout)
+
+        page_records = response.get("data", [])
+        if not isinstance(page_records, list):
+            raise RuntimeError("Response field 'data' is not a list")
+
+        records.extend(page_records)
+        metadata = response
+
+        if not all_pages:
+            break
+
+        total_pages = response.get("total_pages")
+        if not isinstance(total_pages, int):
+            break
+
+        if current_page >= total_pages:
+            break
+
+        current_page += 1
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)
+
+    return records, metadata
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fetch data and export to Excel.")
+    parser.add_argument("--url", required=True, help="Base API URL")
+    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
+    parser.add_argument("--limit", type=int, default=10, help="Page size (default: 10)")
+    parser.add_argument("--keyword", default=None, help="Keyword filter")
+    parser.add_argument(
+        "--enabled",
+        type=parse_bool,
+        default=None,
+        help="Enabled filter: true/false/1/0/yes/no",
+    )
+    parser.add_argument(
+        "--all-pages",
+        action="store_true",
+        help="Fetch all pages until total_pages is reached",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="HTTP timeout in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        default=0.0,
+        help="Sleep seconds between pages (default: 0)",
+    )
+    parser.add_argument(
+        "--output",
+        default="data.xlsx",
+        help="Output Excel file path (default: data.xlsx)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    if args.page < 1:
+        print("page must be >= 1", file=sys.stderr)
+        return 2
+    if args.limit < 1:
+        print("limit must be >= 1", file=sys.stderr)
+        return 2
+
+    try:
+        records, metadata = fetch_pages(
+            base_url=args.url,
+            page=args.page,
+            limit=args.limit,
+            keyword=args.keyword,
+            enabled=args.enabled,
+            all_pages=args.all_pages,
+            timeout=args.timeout,
+            sleep_seconds=args.sleep,
+        )
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        write_excel(records, args.output)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    total = metadata.get("total")
+    total_pages = metadata.get("total_pages")
+    print(
+        f"Done. rows={len(records)} total={total} total_pages={total_pages} output={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fetch_to_excel.py
+++ b/fetch_to_excel.py
@@ -1,273 +1,42 @@
 #!/usr/bin/env python3
-"""
-Fetch paginated data via HTTP GET and export to Excel.
+"""Simple GET -> JSON -> Excel (openpyxl)."""
 
-Example:
-  python fetch_to_excel.py \
-    --url "https://api.example.com/items" \
-    --page 1 --limit 10 --keyword "foo" --enabled true \
-    --all-pages --output "data.xlsx"
-"""
-
-from __future__ import annotations
-
-import argparse
 import json
-import sys
-import time
-from typing import Any, Dict, Iterable, List, Optional, Tuple
-from urllib.error import HTTPError, URLError
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
-from urllib.request import Request, urlopen
+from urllib.parse import urlencode
+from urllib.request import urlopen
 
+from openpyxl import Workbook
 
-FIELD_ORDER = [
-    "id",
-    "position",
-    "document_id",
-    "content",
-    "sign_content",
-    "answer",
-    "word_count",
-    "tokens",
-    "keywords",
-    "index_node_id",
-    "index_node_hash",
-    "hit_count",
-    "enabled",
-    "disabled_at",
-    "disabled_by",
-    "status",
-    "created_by",
-    "created_at",
-    "updated_at",
-    "updated_by",
-    "indexing_at",
-    "completed_at",
-    "error",
-    "stopped_at",
-]
+URL = "https://api.example.com/items"
+PAGE = 1
+LIMIT = 10
+KEYWORD = "foo"  # set to None to omit
+ENABLED = True  # True/False/None
+OUTPUT = "data.xlsx"
 
+params = {
+    "page": PAGE,
+    "limit": LIMIT,
+    "keyword": KEYWORD,
+    "enabled": str(ENABLED).lower() if ENABLED is not None else None,
+}
+params = {k: v for k, v in params.items() if v is not None}
+full_url = URL + ("?" + urlencode(params) if params else "")
 
-def parse_bool(value: Optional[str]) -> Optional[bool]:
-    if value is None:
-        return None
-    value = value.strip().lower()
-    if value in {"true", "1", "yes", "y"}:
-        return True
-    if value in {"false", "0", "no", "n"}:
-        return False
-    raise argparse.ArgumentTypeError(
-        "enabled must be one of: true/false/1/0/yes/no"
-    )
+data = json.loads(urlopen(full_url).read().decode("utf-8"))
+rows = data.get("data", [])
 
+wb = Workbook()
+ws = wb.active
+ws.title = "data"
 
-def build_url(base_url: str, params: Dict[str, Any]) -> str:
-    url_parts = urlsplit(base_url)
-    query_items = dict(parse_qsl(url_parts.query, keep_blank_values=True))
-    for key, value in params.items():
-        if value is None:
-            continue
-        query_items[key] = str(value)
-    new_query = urlencode(query_items, doseq=True)
-    return urlunsplit(
-        (url_parts.scheme, url_parts.netloc, url_parts.path, new_query, url_parts.fragment)
-    )
+if rows:
+    headers = list(rows[0].keys())
+    ws.append(headers)
+    for row in rows:
+        ws.append([row.get(h) for h in headers])
+else:
+    ws.append(["no data"])
 
-
-def http_get_json(url: str, timeout: int) -> Dict[str, Any]:
-    request = Request(url, headers={"Accept": "application/json"})
-    try:
-        with urlopen(request, timeout=timeout) as response:
-            payload = response.read().decode("utf-8")
-    except HTTPError as exc:
-        raise RuntimeError(f"HTTP {exc.code}: {exc.reason}") from exc
-    except URLError as exc:
-        raise RuntimeError(f"Network error: {exc.reason}") from exc
-
-    try:
-        return json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("Response is not valid JSON") from exc
-
-
-def normalize_value(value: Any) -> Any:
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False)
-    return value
-
-
-def build_columns(records: Iterable[Dict[str, Any]]) -> List[str]:
-    extra_keys = set()
-    for record in records:
-        extra_keys.update(record.keys())
-    ordered = [key for key in FIELD_ORDER if key in extra_keys]
-    remaining = sorted(extra_keys - set(ordered))
-    return ordered + remaining
-
-
-def write_excel(records: List[Dict[str, Any]], output_path: str) -> None:
-    try:
-        from openpyxl import Workbook
-        from openpyxl.utils import get_column_letter
-    except ImportError as exc:
-        raise RuntimeError(
-            "Missing dependency: openpyxl. Install with: pip install openpyxl"
-        ) from exc
-
-    workbook = Workbook()
-    sheet = workbook.active
-    sheet.title = "data"
-
-    if not records:
-        sheet.append(["no data"])
-        workbook.save(output_path)
-        return
-
-    columns = build_columns(records)
-    sheet.append(columns)
-
-    for record in records:
-        row = [normalize_value(record.get(column)) for column in columns]
-        sheet.append(row)
-
-    # Light column sizing for readability (cap width at 50).
-    for idx, column_name in enumerate(columns, start=1):
-        max_len = len(str(column_name))
-        for row_idx in range(2, min(sheet.max_row, 2000) + 1):
-            value = sheet.cell(row=row_idx, column=idx).value
-            if value is None:
-                continue
-            max_len = max(max_len, len(str(value)))
-        sheet.column_dimensions[get_column_letter(idx)].width = min(50, max(10, max_len + 2))
-
-    workbook.save(output_path)
-
-
-def fetch_pages(
-    base_url: str,
-    page: int,
-    limit: int,
-    keyword: Optional[str],
-    enabled: Optional[bool],
-    all_pages: bool,
-    timeout: int,
-    sleep_seconds: float,
-) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
-    records: List[Dict[str, Any]] = []
-    metadata: Dict[str, Any] = {}
-
-    current_page = page
-    while True:
-        params = {
-            "page": current_page,
-            "limit": limit,
-            "keyword": keyword,
-            "enabled": str(enabled).lower() if enabled is not None else None,
-        }
-        url = build_url(base_url, params)
-        response = http_get_json(url, timeout=timeout)
-
-        page_records = response.get("data", [])
-        if not isinstance(page_records, list):
-            raise RuntimeError("Response field 'data' is not a list")
-
-        records.extend(page_records)
-        metadata = response
-
-        if not all_pages:
-            break
-
-        total_pages = response.get("total_pages")
-        if not isinstance(total_pages, int):
-            break
-
-        if current_page >= total_pages:
-            break
-
-        current_page += 1
-        if sleep_seconds > 0:
-            time.sleep(sleep_seconds)
-
-    return records, metadata
-
-
-def build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Fetch data and export to Excel.")
-    parser.add_argument("--url", required=True, help="Base API URL")
-    parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    parser.add_argument("--limit", type=int, default=10, help="Page size (default: 10)")
-    parser.add_argument("--keyword", default=None, help="Keyword filter")
-    parser.add_argument(
-        "--enabled",
-        type=parse_bool,
-        default=None,
-        help="Enabled filter: true/false/1/0/yes/no",
-    )
-    parser.add_argument(
-        "--all-pages",
-        action="store_true",
-        help="Fetch all pages until total_pages is reached",
-    )
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=30,
-        help="HTTP timeout in seconds (default: 30)",
-    )
-    parser.add_argument(
-        "--sleep",
-        type=float,
-        default=0.0,
-        help="Sleep seconds between pages (default: 0)",
-    )
-    parser.add_argument(
-        "--output",
-        default="data.xlsx",
-        help="Output Excel file path (default: data.xlsx)",
-    )
-    return parser
-
-
-def main() -> int:
-    parser = build_arg_parser()
-    args = parser.parse_args()
-
-    if args.page < 1:
-        print("page must be >= 1", file=sys.stderr)
-        return 2
-    if args.limit < 1:
-        print("limit must be >= 1", file=sys.stderr)
-        return 2
-
-    try:
-        records, metadata = fetch_pages(
-            base_url=args.url,
-            page=args.page,
-            limit=args.limit,
-            keyword=args.keyword,
-            enabled=args.enabled,
-            all_pages=args.all_pages,
-            timeout=args.timeout,
-            sleep_seconds=args.sleep,
-        )
-    except RuntimeError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
-
-    try:
-        write_excel(records, args.output)
-    except RuntimeError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
-
-    total = metadata.get("total")
-    total_pages = metadata.get("total_pages")
-    print(
-        f"Done. rows={len(records)} total={total} total_pages={total_pages} output={args.output}"
-    )
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+wb.save(OUTPUT)
+print(f"done, rows={len(rows)}, output={OUTPUT}")

--- a/fetch_to_excel.py
+++ b/fetch_to_excel.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
-"""Simple GET -> JSON -> Excel (openpyxl), auto paging."""
+"""Simple GET -> JSON -> TXT (one line per record), auto paging."""
 
 import json
 import time
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from openpyxl import Workbook
-
 URL = "https://api.example.com/items"
 START_PAGE = 1
 LIMIT = 10
 KEYWORD = "foo"  # set to None to omit
 ENABLED = True  # True/False/None
-OUTPUT = "data.xlsx"
+OUTPUT = "data.txt"
 SLEEP = 0.0  # seconds between pages
 
 # headers for request (add token/cookie here)
@@ -52,17 +50,8 @@ while True:
     if SLEEP > 0:
         time.sleep(SLEEP)
 
-wb = Workbook()
-ws = wb.active
-ws.title = "data"
-
-if all_rows:
-    headers = list(all_rows[0].keys())
-    ws.append(headers)
+with open(OUTPUT, "w", encoding="utf-8") as file:
     for row in all_rows:
-        ws.append([row.get(h) for h in headers])
-else:
-    ws.append(["no data"])
+        file.write(json.dumps(row, ensure_ascii=False) + "\n")
 
-wb.save(OUTPUT)
 print(f"done, rows={len(all_rows)}, output={OUTPUT}, total_pages={total_pages}")

--- a/fetch_to_excel.py
+++ b/fetch_to_excel.py
@@ -1,42 +1,68 @@
 #!/usr/bin/env python3
-"""Simple GET -> JSON -> Excel (openpyxl)."""
+"""Simple GET -> JSON -> Excel (openpyxl), auto paging."""
 
 import json
+import time
 from urllib.parse import urlencode
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from openpyxl import Workbook
 
 URL = "https://api.example.com/items"
-PAGE = 1
+START_PAGE = 1
 LIMIT = 10
 KEYWORD = "foo"  # set to None to omit
 ENABLED = True  # True/False/None
 OUTPUT = "data.xlsx"
+SLEEP = 0.0  # seconds between pages
 
-params = {
-    "page": PAGE,
-    "limit": LIMIT,
-    "keyword": KEYWORD,
-    "enabled": str(ENABLED).lower() if ENABLED is not None else None,
+# headers for request (add token/cookie here)
+HEADERS = {
+    "Accept": "application/json",
+    # "Authorization": "Bearer xxx",
 }
-params = {k: v for k, v in params.items() if v is not None}
-full_url = URL + ("?" + urlencode(params) if params else "")
 
-data = json.loads(urlopen(full_url).read().decode("utf-8"))
-rows = data.get("data", [])
+all_rows = []
+page = START_PAGE
+total_pages = None
+
+while True:
+    params = {
+        "page": page,
+        "limit": LIMIT,
+        "keyword": KEYWORD,
+        "enabled": str(ENABLED).lower() if ENABLED is not None else None,
+    }
+    params = {k: v for k, v in params.items() if v is not None}
+    full_url = URL + ("?" + urlencode(params) if params else "")
+
+    req = Request(full_url, headers=HEADERS)
+    data = json.loads(urlopen(req).read().decode("utf-8"))
+    rows = data.get("data", [])
+    if isinstance(rows, list):
+        all_rows.extend(rows)
+    else:
+        raise RuntimeError("response data is not a list")
+
+    total_pages = data.get("total_pages", total_pages)
+    if total_pages is None or page >= total_pages:
+        break
+
+    page += 1
+    if SLEEP > 0:
+        time.sleep(SLEEP)
 
 wb = Workbook()
 ws = wb.active
 ws.title = "data"
 
-if rows:
-    headers = list(rows[0].keys())
+if all_rows:
+    headers = list(all_rows[0].keys())
     ws.append(headers)
-    for row in rows:
+    for row in all_rows:
         ws.append([row.get(h) for h in headers])
 else:
     ws.append(["no data"])
 
 wb.save(OUTPUT)
-print(f"done, rows={len(rows)}, output={OUTPUT}")
+print(f"done, rows={len(all_rows)}, output={OUTPUT}, total_pages={total_pages}")


### PR DESCRIPTION
Add `fetch_to_excel.py` script to fetch paginated API data via GET requests and export it to an Excel file.

---
<a href="https://cursor.com/background-agent?bcId=bc-44c5d19b-35f7-4593-8310-1ba3e39bd9a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44c5d19b-35f7-4593-8310-1ba3e39bd9a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

